### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Example: Transmit a packet to another node
 Example: Receive packets
 ------------------------
 
-	xbee = XBee::XBee.new port: '/dev/ttyUSB0', rate: 115200
+	xbee = XBee::XBee.new device_path: '/dev/ttyUSB0', rate: 115200
 	xbee.open
 	loop do
 		frame = xbee.read_frame


### PR DESCRIPTION
Correctly use :device_path instead of :path 

Not doing so results in:
```
/var/lib/gems/2.7.0/gems/xbee-1.0.2/lib/xbee/xbee.rb:37:in `initialize': unknown keyword: :port (ArgumentError)
```